### PR TITLE
Do not add vendored packages to packagelist for autoimport

### DIFF
--- a/pythonx/px/go.py
+++ b/pythonx/px/go.py
@@ -210,6 +210,8 @@ def get_all_imports():
 
     for info in golist.split("\n"):
         name, path = info.split(':')
+        if "/vendor/" in path:
+            continue
         _imports_cache[name] = path
 
     return _imports_cache


### PR DESCRIPTION
This prevent auto importing packages with import path like `some/package/vendor/package`