### PR TITLE
add sorting go imports by descending length

### DIFF
--- a/pythonx/px/go.py
+++ b/pythonx/px/go.py
@@ -208,7 +208,12 @@ def get_all_imports():
         ['go', 'list', '-f', '{{.Name}}:{{.ImportPath}}', '...']
     ).strip()
 
-    for info in golist.split("\n"):
+    # sort imports by descending length, it will make some priority for stdlib
+    # packages
+    imports = golist.split("\n")
+    imports.sort(key=len, reverse=True)
+
+    for info in imports:
         name, path = info.split(':')
         if "/vendor/" in path:
             continue


### PR DESCRIPTION
I think it will good work for some troubles, when thirdparty packages named
like stdlib (log, for example), also it will fix problem with `syscall` package
(from time to time, vim-pythonx imports `internal/syscall` instead of `syscall`)


What you think about it?